### PR TITLE
Adding optional UID function

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -40,8 +40,7 @@ function setup_user () {
     chown ${username}:users /home/${username}/.ssh
 
     echo "Adding authorized keys..."
-    mkdir /home/${username}/.ssh/authorized_keys
-    cp ${keyfile} /home/${username}/.ssh/authorized_keys/${username}.pub
+    cp ${keyfile} /home/${username}/.ssh/authorized_keys
     chown -R ${username}:users /home/${username}/.ssh
     chmod 0644 /home/${username}/.ssh/authorized_keys
 }

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -10,10 +10,23 @@ fi
 
 function setup_user () {
     keyfile=$1
-    username=$(basename ${keyfile%.*})
+    filename=$(basename ${keyfile%.*})
+
+    readarray -d "." -t arr < <(printf '%s' "$filename")
+
+    username=${arr[0]}
+    uid=${arr[1]}
 
     echo "Adding user $username for $keyfile..."
-    adduser --disabled-password --ingroup users --home /home/${username} ${username}
+
+    if [[ -z "${uid}" ]]; then
+      #echo "No UID given"
+      adduser --disabled-password --ingroup users --home /home/${username} ${username}
+    else
+      echo "Using UID $uid"
+       adduser --disabled-password --ingroup users --uid $uid --home /home/${username} ${username}
+    fi
+
     # Set random long secure password on user so logins are possible
     pass=$(cat /dev/urandom | head -c 2048 | sha256sum | head -c 64; echo | mkpasswd)
     echo "${username}:${pass}" | chpasswd
@@ -27,7 +40,8 @@ function setup_user () {
     chown ${username}:users /home/${username}/.ssh
 
     echo "Adding authorized keys..."
-    cp ${keyfile} /home/${username}/.ssh/authorized_keys
+    mkdir /home/${username}/.ssh/authorized_keys
+    cp ${keyfile} /home/${username}/.ssh/authorized_keys/${username}.pub
     chown -R ${username}:users /home/${username}/.ssh
     chmod 0644 /home/${username}/.ssh/authorized_keys
 }


### PR DESCRIPTION
Via this change, a predefined UID can be given for each user.
It might be useful for cross-shared folders/volumes between host and container.

This is done by an special key file format, as UNIX-usernames forbid dots:
USERNAME.UID.pub

e.g.: user.1234.pub